### PR TITLE
Bash History Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ A class for managing the bashrc configuration files
 ##### `template_etc_bashrc`
 ##### `template_etc_profile`
 ##### `users`
+##### `history_control`
+##### `history_size`
+##### `history_file_size`
+##### `history_time_format`
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@ class bashrc(
   $template_etc_bashrc      = $bashrc::params::template_etc_bashrc,
   $template_etc_profile     = $bashrc::params::template_etc_profile,
 
+  $history_control          = $bashrc::params::history_control,
+  $history_size             = $bashrc::params::history_size,
+  $history_file_size        = $bashrc::params::history_file_size,
+  $history_time_format      = $bashrc::params::history_time_format,
 
   )inherits bashrc::params {
   validate_re($package_ensure, '^(absent|latest|present|purged)$')
@@ -64,12 +68,16 @@ class bashrc(
   validate_string($ps1_colored)
   validate_string($ps1_screen)
 
+  validate_string($history_control)
+  validate_string($history_size)
+  validate_string($history_file_size)
+  validate_string($history_time_format)
   #validate_absolute_path($template_etc_bashrc)
   #validate_absolute_path($template_etc_profile)
 
-  anchor { 'bashrc::begin': } ->
-  class{'bashrc::install': } ->
-  class{'bashrc::config': } ->
-  anchor { 'bashrc::end': }
+  anchor { 'bashrc::begin': } 
+  -> class{'bashrc::install': } 
+  -> class{'bashrc::config': } 
+  -> anchor { 'bashrc::end': }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,10 @@ class bashrc::params {
   $manage_custom_bashrc     = true
   $manage_etc_files         = true
   $manage_skeltons          = true
+  $history_control          = 'ignoreboth'
+  $history_size             = '1000'
+  $history_file_size        = '2000'
+  $history_time_format      = '"[ %d/%m/%y %T ] "'
 
   $ps1_default              = '\u@\h:\w\$ '
   $ps1_colored              = '\[\033[38;5;1m\]\$?\[$(tput sgr0)\],\[\033[38;5;214m\]\t\[$(tput sgr0)\],\[\033[38;5;34m\]\u@\H\[$(tput sgr0)\]:\[\033[38;5;27m\]\w\[$(tput sgr0)\]\[\033[38;5;15m\]\\$\[$(tput sgr0)\] '

--- a/templates/user/bashrc.erb
+++ b/templates/user/bashrc.erb
@@ -12,15 +12,15 @@ esac
 
 # don't put duplicate lines or lines starting with space in the history.
 # See bash(1) for more options
-HISTCONTROL=ignoreboth
+HISTCONTROL=<%= @history_control %> 
 
 # append to the history file, don't overwrite it
 shopt -s histappend
 
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
-HISTSIZE=1000
-HISTFILESIZE=2000
-HISTTIMEFORMAT="[ %d/%m/%y %T ] "
+HISTSIZE=<%= @history_size %>
+HISTFILESIZE=<%= @history_file_size %>
+HISTTIMEFORMAT=<%= @history_time_format %>
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.


### PR DESCRIPTION
Adding in the ability to customize the bash history controls in the user bashrc. Also fixed the "WARNING: arrow should be on the right operands line" that would come up on puppet lint. 