### PR TITLE
Support concat 4.2.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
         },
         {
             "name": "puppetlabs-concat",
-            "version_requirement": ">= 1.0.0 < 3.0.0"
+            "version_requirement": ">= 1.0.0 < 5.0.0"
         }
     ],
     "requirements": [

--- a/templates/skel/bashrc_Debian.erb
+++ b/templates/skel/bashrc_Debian.erb
@@ -12,14 +12,15 @@ esac
 
 # don't put duplicate lines or lines starting with space in the history.
 # See bash(1) for more options
-HISTCONTROL=ignoreboth
+HISTCONTROL=<%= @history_control %> 
 
 # append to the history file, don't overwrite it
 shopt -s histappend
 
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
-HISTSIZE=1000
-HISTFILESIZE=2000
+HISTSIZE=<%= @history_size %>
+HISTFILESIZE=<%= @history_file_size %>
+HISTTIMEFORMAT=<%= @history_time_format %>
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.


### PR DESCRIPTION
#### Pull Request (PR) description
The Amanda module lags behind in supporting the latest puppetlabs/concat and puppetlabs/xinetd. This blocks the install of other modules which need more up to date concat/xinetd releases.

These are the xinetd changes since 3.0.0:
* All changes in this release are for enabling rubocop, alongside the module then being converted over to the PDK.
* Rubocop has been implemented.
* SLES 10, Windows 2003 R2 and OSX 10.9 removed as supported.
* OSX 10.10 and 10.11 added as supported.
* stdlib dependency changed to 4.13.1
* supported Puppet version changed to 4.7.

Seems to be okay for the Bashrc module.

#### This Pull Request (PR) fixes the following issues
For managelocalbashrc (~/.bashrc), the following parameters where ignored:
* history_control
* history_size
* history_file_size
* history_time_format
