### PR TITLE
Support unalias in custompuppet-basicaliases.sh

### DIFF
--- a/templates/etc/bashrc.d/custompuppet-basicaliases.sh
+++ b/templates/etc/bashrc.d/custompuppet-basicaliases.sh
@@ -19,7 +19,7 @@ unalias <%= myalias['name'] %>
 alias <%= myalias['name'] %>='<%= myalias['value'] %>'
 <%     end -%>
 <%   else -%>
-alias <%= name %>
+alias <%= myalias %>
 <%   end -%>
 <% end -%>
 

--- a/templates/etc/bashrc.d/custompuppet-basicaliases.sh
+++ b/templates/etc/bashrc.d/custompuppet-basicaliases.sh
@@ -12,6 +12,14 @@ alias l='ls -CF'
 
 #Machine specific aliases
 <% @aliases.each do |myalias| -%>
-alias <%= myalias %>
+<%   if myalias.is_a?(Hash) -%>
+<%     if myalias['value'] == nil -%>
+unalias <%= myalias['name'] %>
+<%     else -%>
+alias <%= myalias['name'] %>='<%= myalias['value'] %>'
+<%     end -%>
+<%   else -%>
+alias <%= name %>
+<%   end -%>
 <% end -%>
 


### PR DESCRIPTION
Restructure the bashrc::aliases definition to allow unalias an alias. Change is backwards compatible with existing installations.